### PR TITLE
fix mysql restart not happening because of missing os specific variable

### DIFF
--- a/roles/ansible-mysql-hardening/handlers/main.yml
+++ b/roles/ansible-mysql-hardening/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: restart mysql
-  service: name='{{}}' state=restarted
+  service: name='{{ mysql_daemon }}' state=restarted

--- a/roles/ansible-mysql-hardening/vars/Debian.yml
+++ b/roles/ansible-mysql-hardening/vars/Debian.yml
@@ -1,1 +1,2 @@
+mysql_daemon: mysql
 mysql_hardening_mysql_conf: '/etc/mysql/my.cnf'

--- a/roles/ansible-mysql-hardening/vars/Oracle Linux.yml
+++ b/roles/ansible-mysql-hardening/vars/Oracle Linux.yml
@@ -1,1 +1,2 @@
+mysql_daemon: mysqld
 mysql_hardening_mysql_conf: '/etc/my.cnf'

--- a/roles/ansible-mysql-hardening/vars/RedHat.yml
+++ b/roles/ansible-mysql-hardening/vars/RedHat.yml
@@ -1,1 +1,2 @@
+mysql_daemon: mysql
 mysql_hardening_mysql_conf: '/etc/my.cnf'


### PR DESCRIPTION
the playbook's mysql restart handler was missing its daemon name, throwing a template error. OS specific daemon names have been added