### PR TITLE
Simplify local testing with custom role

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   hosts: all
   require_ansible_repo: false
   require_ansible_omnibus: true
+  requirements_path: requirements.txt
 platforms:
 - name: ubuntu-12.04
   driver_config:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ ansible-galaxy install -p roles/ bennojoy.mysql
 # change password in MySQL-installation role to match the one from testing
 sed -i 's/foobar/iloverandompasswordsbutthiswilldo/g' roles/bennojoy.mysql/defaults/main.yml
 
-
 # fast test on one machine
 bundle exec kitchen test default-ubuntu-1204
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+zufallsheld.mysql


### PR DESCRIPTION
Can be merged after https://github.com/hardening-io/tests-mysql-hardening/pull/28

This simplifies testing as there are 2 manual steps less to be performed.