### PR TITLE
add webhook for ansible galaxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/
 language: python
 python: "2.7"
 before_install:


### PR DESCRIPTION
This way the build status is shown on ansible-galaxy.